### PR TITLE
Respect Bundler config

### DIFF
--- a/lib/tara/archive.rb
+++ b/lib/tara/archive.rb
@@ -37,6 +37,8 @@ module Tara
     #   the application.
     # @option config [String] :build_dir (File.join(@config[:app_dir], 'build'))
     #   the directory where the archive will be created.
+    # @option config [Boolean] :bundle_ignore_config (false)
+    #   if Bundler config should be ignored when installing dependencies
     # @option config [String] :download_dir (File.join(@config[:build_dir], 'downloads'))
     #   the directory where Traveling Ruby artifacts will be downloaded.
     # @option config [String] :archive_name (@config[:app_name] + '.tgz') name of the archive

--- a/lib/tara/installer.rb
+++ b/lib/tara/installer.rb
@@ -8,6 +8,7 @@ module Tara
       @fetcher = fetcher
       @without_groups = options[:without_groups]
       @app_dir = Pathname.new(options[:app_dir])
+      @bundle_env = 'BUNDLE_IGNORE_CONFIG=1' if options[:bundle_ignore_config]
       @shell = options[:shell] || Shell
     end
 
@@ -27,7 +28,7 @@ module Tara
 
     def bundler_command
       @bundler_command ||= begin
-        command = 'BUNDLE_IGNORE_CONFIG=1 bundle install --jobs 4 --path vendor'
+        command = "#{@bundle_env} bundle install --jobs 4 --path vendor"
         command << %( --without #{@without_groups.join(' ')}) if @without_groups.any?
         command
       end


### PR DESCRIPTION
Currently Tara sets BUNDLE_IGNORE_CONFIG=1 when installing dependencies. This causes problems when the credentials for a gem repo is stored in the config and not in the Gemfile, see https://github.com/phusion/traveling-ruby/issues/53.

This changes so that by default this environment variable is not set, and a config option `:bundle_ignore_config` is added to set it.