### PR TITLE
Create shims for gem executables

### DIFF
--- a/lib/tara/archive.rb
+++ b/lib/tara/archive.rb
@@ -46,6 +46,8 @@ module Tara
     #   expanded when including source files in archive. Should be relative from :app_dir.
     # @option config [Array<String>] :executables (%w[bin/*]) list of globs that will be
     #   expanded when including executables in archive. Should be relative from :app_dir.
+    # @option config [Array<String, String>] :gem_executables ([]) list of gem and exec name
+    #   pairs which will be included as executables in archive.
     # @option config [String] :target (linux-x86_64) target platform that the archive will
     #   be created for. Should be one of "linux-x86", "linux-x86_64", or "osx".
     # @option config [String] :traveling_ruby_version (20150210) release of Traveling Ruby
@@ -62,6 +64,7 @@ module Tara
       @config[:archive_name] ||= @config[:app_name] + '.tgz'
       @config[:files] ||= %w[lib/**/*.rb]
       @config[:executables] ||= %w[bin/*]
+      @config[:gem_executables] ||= []
       @config[:target] ||= 'linux-x86_64'
       @config[:traveling_ruby_version] ||= '20150210'
       @config[:without_groups] ||= %w[development test]
@@ -88,6 +91,9 @@ module Tara
         install_dependencies(package_dir, fetcher)
         copy_source(project_dir, package_dir)
         copy_executables(project_dir, package_dir)
+        @config[:gem_executables].each do |gem_name, exec_name|
+          create_gem_shim(package_dir, gem_name, exec_name)
+        end
         Dir.chdir(tmp_dir) do
           create_archive(build_dir)
         end
@@ -149,6 +155,13 @@ module Tara
     def create_shim(package_dir, executable)
       shim_path = package_dir.join(executable.basename)
       shim = Shim.new(*executable.split)
+      File.open(shim_path, 'w') { |f| shim.write(f) }
+      FileUtils.chmod(0755, shim_path)
+    end
+
+    def create_gem_shim(package_dir, gem_name, exec_name)
+      shim_path = package_dir.join(exec_name)
+      shim = GemShim.new(gem_name, exec_name)
       File.open(shim_path, 'w') { |f| shim.write(f) }
       FileUtils.chmod(0755, shim_path)
     end

--- a/lib/tara/archiver.rb
+++ b/lib/tara/archiver.rb
@@ -31,6 +31,8 @@ module Tara
     #   expanded when including source files in archive. Should be relative from `:app_dir`.
     # @option config [Array<String>] :executables (%w[bin/*]) list of globs that will be
     #   expanded when including executables in archive. Should be relative from `:app_dir`.
+    # @option config [Array<String, String>] :gem_executables ([]) list of gem and exec name
+    #   pairs which will be included as executables in archive.
     # @option config [String] :target (linux-x86_64) target platform that the archive will
     #   be created for. Should be one of "linux-x86", "linux-x86_64", or "osx".
     # @option config [String] :traveling_ruby_version (20150210) release of Traveling Ruby

--- a/lib/tara/shim.rb
+++ b/lib/tara/shim.rb
@@ -2,10 +2,9 @@
 
 module Tara
   # @private
-  class Shim
-    def initialize(dirpath, name)
-      @dirpath = dirpath
-      @name = name
+  class BaseShim
+    def initialize(command)
+      @command = command
     end
 
     def write(io)
@@ -21,8 +20,22 @@ module Tara
         SELF_DIR=$(dirname "$0")
         export BUNDLE_GEMFILE="$SELF_DIR/lib/vendor/Gemfile"
         unset BUNDLE_IGNORE_CONFIG
-        exec "$SELF_DIR/lib/ruby/bin/ruby" -rbundler/setup "$SELF_DIR/#{@dirpath}/#{@name}" "$@"
+        exec "$SELF_DIR/lib/ruby/bin/ruby" -rbundler/setup #{@command}
       EOH
+    end
+  end
+
+  # @private
+  class Shim < BaseShim
+    def initialize(dirpath, name)
+      super(%("$SELF_DIR/#{dirpath}/#{name}" "$@"))
+    end
+  end
+
+  # @private
+  class GemShim < BaseShim
+    def initialize(gem_name, exec_name)
+     super(%(-e "load Gem.bin_path('#{gem_name}', '#{exec_name}')" -- "$@"))
     end
   end
 end

--- a/spec/acceptance/archive_spec.rb
+++ b/spec/acceptance/archive_spec.rb
@@ -143,6 +143,7 @@ module Tara
           create_archive(tmpdir, {
             files: %w[lib/*],
             executables: %w[bin/* ext/*],
+            gem_executables: [['rack', 'rackup']],
             target: detect_target,
             download_dir: download_dir,
             without_groups: %w[ignore],
@@ -164,6 +165,11 @@ module Tara
           expect(listing).to include('nonbin')
           output = %x(cd #{File.dirname(archive_path)} && ./nonbin)
           expect(output.strip).to eq('Hello world')
+        end
+
+        it 'correctly creates wrapper scripts for gem executables' do
+          output = %x(cd #{File.dirname(archive_path)} && ./rackup --version)
+          expect(output.strip).to eq('Rack 1.3 (Release: 1.5)')
         end
       end
     end


### PR DESCRIPTION
Certain gems provide useful executables, for example rack and whenever. This change makes it possible to specify executables from gems that also will get shims. Example `gem_executables: [['rack', 'rackup']]` will create the `rackup` shim.