### PR TITLE
Fixed directory copying

### DIFF
--- a/lib/tara/archive.rb
+++ b/lib/tara/archive.rb
@@ -150,7 +150,6 @@ module Tara
         unless (dirname = relative_file.dirname) == DOT_PATH
           FileUtils.mkdir_p(package_dir.join(dirname))
         end
-        FileUtils.cp_r(file, package_dir.join(relative_file))
       else
         unless (dirname = relative_file.dirname) == DOT_PATH
           FileUtils.mkdir_p(package_dir.join(dirname))

--- a/spec/acceptance/archive_spec.rb
+++ b/spec/acceptance/archive_spec.rb
@@ -141,7 +141,7 @@ module Tara
       context 'with custom options' do
         before :all do
           create_archive(tmpdir, {
-            files: %w[lib/*],
+            files: %w[lib/**/*],
             executables: %w[bin/* ext/*],
             gem_executables: [['rack', 'rackup']],
             target: detect_target,
@@ -155,6 +155,11 @@ module Tara
 
         it 'recursively includes source files' do
           expect(listing).to include('lib/exapp/cli.rb')
+        end
+
+        it 'does not get confused by deep directory trees' do
+          expect(listing).to include('lib/exapp/data/reader.rb')
+          expect(listing).to_not include('lib/exapp/data/data/reader.rb')
         end
 
         it 'excludes gems in given `without_groups` option' do

--- a/spec/resources/exapp/lib/exapp/data/reader.rb
+++ b/spec/resources/exapp/lib/exapp/data/reader.rb
@@ -1,0 +1,8 @@
+# encoding: utf-8
+
+module Exapp
+  module Data
+    class Reader
+    end
+  end
+end


### PR DESCRIPTION
This pull request fixes a bug where Globs containing directories would lead to the directory being copied twice