### PR TITLE
Copy gems from local gemset

### DIFF
--- a/lib/ext/bundler.rb
+++ b/lib/ext/bundler.rb
@@ -2,10 +2,11 @@ require 'bundler'
 module Bundler
   class Definition
     def add_optional_group(group)
+      @optional_groups ||= []
       @optional_groups << group.to_sym
     end
-    def optional_groups
-      @optional_groups
+    def has_optional_groups?
+      @optional_groups && @optional_groups.is_a?(Array)
     end
   end
 end

--- a/lib/ext/bundler.rb
+++ b/lib/ext/bundler.rb
@@ -1,0 +1,11 @@
+require 'bundler'
+module Bundler
+  class Definition
+    def add_optional_group(group)
+      @optional_groups << group.to_sym
+    end
+    def optional_groups
+      @optional_groups
+    end
+  end
+end

--- a/lib/tara.rb
+++ b/lib/tara.rb
@@ -3,7 +3,7 @@
 require 'bundler'
 require 'pathname'
 require 'tmpdir'
-
+require 'ext/bundler'
 
 module Tara
   TaraError = Class.new(StandardError)

--- a/lib/tara/installer.rb
+++ b/lib/tara/installer.rb
@@ -35,7 +35,7 @@ module Tara
 
     def bundler_command
       @bundler_command ||= begin
-        command = 'bundle install --jobs 4 --path . --gemfile lib/vendor/Gemfile'
+        command = 'bundle install --jobs 4 --frozen --path . --gemfile lib/vendor/Gemfile'
         command << %( --without #{@without_groups.join(' ')}) if @without_groups.any?
         command
       end

--- a/lib/tara/installer.rb
+++ b/lib/tara/installer.rb
@@ -73,11 +73,8 @@ module Tara
       definition.specs.each_with_object([]) do |gem_spec, specs|
         if gem_spec.full_gem_path.start_with?(Bundler.bundle_path.to_s) # Local gem
           specs << {
-            :name => gem_spec.name,
-            :full_name => gem_spec.full_name,
             :full_gem_path => gem_spec.full_gem_path,
             :spec_file => gem_spec.spec_file,
-            :bin_dir => gem_spec.bin_dir,
             :relative_path => Pathname.new(gem_spec.full_gem_path).relative_path_from(Bundler.bundle_path).to_s,
           }
         end
@@ -91,9 +88,8 @@ module Tara
       target_directory = File.join(@package_dir, 'lib/vendor', Bundler.ruby_scope)
 
       spec_dir = File.join(target_directory, 'specifications')
-      bin_dir = File.join(target_directory, 'bin')
       FileUtils.mkdir_p(spec_dir)
-      FileUtils.mkdir_p(bin_dir)
+      FileUtils.mkdir_p(File.join(target_directory, 'bin'))
       FileUtils.mkdir_p(File.join(target_directory, 'gems'))
       FileUtils.mkdir_p(File.join(target_directory, 'bundler', 'gems'))
 

--- a/lib/tara/installer.rb
+++ b/lib/tara/installer.rb
@@ -1,5 +1,17 @@
 # encoding: utf-8
 
+require 'bundler'
+module Bundler
+  class Definition
+    def add_optional_group(group)
+      @optional_groups << group.to_sym
+    end
+    def optional_groups
+      @optional_groups
+    end
+  end
+end
+
 module Tara
   # @private
   class Installer
@@ -67,6 +79,9 @@ module Tara
     def find_installed_gems
       Bundler.with_clean_env do
         definition = Bundler::Definition.build('lib/vendor/Gemfile', 'lib/vendor/Gemfile.lock', false)
+        @without_groups.each do |group|
+          definition.add_optional_group(group)
+        end
         specs = definition.specs.map do |gem_spec|
           spec = {
             :name => gem_spec.name,

--- a/lib/tara/installer.rb
+++ b/lib/tara/installer.rb
@@ -98,6 +98,7 @@ module Tara
     end
 
     def copy_local_gems
+      git_gems = find_all_git_gems
       local_gems = find_installed_gems
       target_directory = File.join(@package_dir, 'lib/vendor', Bundler.ruby_scope)
 
@@ -113,7 +114,7 @@ module Tara
         FileUtils.cp(gemspec[:spec_file], spec_dir) if File.exists?(gemspec[:spec_file])
       end
 
-      find_all_git_gems.each do |relative_path|
+      git_gems.each do |relative_path|
         FileUtils.mkdir_p(File.join(target_directory, relative_path))
       end
     end

--- a/lib/tara/installer.rb
+++ b/lib/tara/installer.rb
@@ -86,19 +86,7 @@ module Tara
       []
     end
 
-    def find_all_git_gems
-      definition = Bundler::Definition.build('lib/vendor/Gemfile', 'lib/vendor/Gemfile.lock', false)
-      definition.specs.each_with_object([]) do |gem_spec, git_list|
-        if %r{(.+bundler/gems/.+-[a-f0-9]{7,12})}.match(gem_spec.full_gem_path)
-          git_list << Pathname.new(gem_spec.full_gem_path).relative_path_from(Bundler.bundle_path).to_s
-        end
-      end
-    rescue Bundler::GemNotFound => e
-      []
-    end
-
     def copy_local_gems
-      git_gems = find_all_git_gems
       local_gems = find_installed_gems
       target_directory = File.join(@package_dir, 'lib/vendor', Bundler.ruby_scope)
 
@@ -112,10 +100,6 @@ module Tara
       local_gems.each do |gemspec|
         FileUtils.cp_r(gemspec[:full_gem_path], File.join(target_directory, gemspec[:relative_path]))
         FileUtils.cp(gemspec[:spec_file], spec_dir) if File.exists?(gemspec[:spec_file])
-      end
-
-      git_gems.each do |relative_path|
-        FileUtils.mkdir_p(File.join(target_directory, relative_path))
       end
     end
 

--- a/lib/tara/installer.rb
+++ b/lib/tara/installer.rb
@@ -81,6 +81,8 @@ module Tara
           spec
         end
       end
+    rescue Bundler::GemNotFound => e
+      []
     end
 
     def copy_local_gems

--- a/lib/tara/installer.rb
+++ b/lib/tara/installer.rb
@@ -66,6 +66,7 @@ module Tara
 
     def find_installed_gems
       definition = Bundler::Definition.build('lib/vendor/Gemfile', 'lib/vendor/Gemfile.lock', false)
+      return [] unless definition.has_optional_groups?
       @without_groups.each do |group|
         definition.add_optional_group(group)
       end

--- a/lib/tara/installer.rb
+++ b/lib/tara/installer.rb
@@ -45,6 +45,7 @@ module Tara
       FileUtils.mkdir_p(vendor_path)
       copy_gem_files(vendor_path)
       Dir.chdir(@package_dir) do
+        copy_local_gems
         Bundler.with_clean_env do
           @shell.exec_with_env(bundler_command, @bundle_env)
           if @build_command
@@ -59,6 +60,45 @@ module Tara
         end
         %w[o so bundle].each do |ext|
           find_and_remove_files('lib/vendor/ruby/*/gems', %(*.#{ext}))
+        end
+      end
+    end
+
+    def find_installed_gems
+      Bundler.with_clean_env do
+        definition = Bundler::Definition.build('lib/vendor/Gemfile', 'lib/vendor/Gemfile.lock', false)
+        specs = definition.specs.map do |gem_spec|
+          spec = {
+            :name => gem_spec.name,
+            :full_name => gem_spec.full_name,
+            :full_gem_path => gem_spec.full_gem_path,
+            :spec_file => gem_spec.spec_file,
+            :bin_dir => gem_spec.bin_dir,
+          }
+          if spec[:full_gem_path].start_with?(Bundler.bundle_path.to_s) # Local gem
+            spec[:relative_path] = Pathname.new(spec[:full_gem_path]).relative_path_from(Bundler.bundle_path).to_s
+          end
+          spec
+        end
+      end
+    end
+
+    def copy_local_gems
+      local_gems = find_installed_gems
+      target_directory = File.join(@package_dir, 'lib/vendor', Bundler.ruby_scope)
+
+      Bundler.with_clean_env do
+        spec_dir = File.join(target_directory, 'specifications')
+        bin_dir = File.join(target_directory, 'bin')
+        FileUtils.mkdir_p(spec_dir)
+        FileUtils.mkdir_p(bin_dir)
+        FileUtils.mkdir_p(File.join(target_directory, 'gems'))
+        FileUtils.mkdir_p(File.join(target_directory, 'bundler/gems'))
+
+        local_gems.each do |gemspec|
+          next unless gemspec[:relative_path]
+          FileUtils.cp_r(gemspec[:full_gem_path], File.join(target_directory, gemspec[:relative_path]))
+          FileUtils.cp(gemspec[:spec_file], spec_dir) if File.exists?(gemspec[:spec_file])
         end
       end
     end

--- a/spec/integration/cli_integration_spec.rb
+++ b/spec/integration/cli_integration_spec.rb
@@ -73,7 +73,7 @@ describe 'bin/tara' do
     end
 
     it 'prints error message to given stream' do
-      Tara::Cli.new([], io).run
+      Tara::Cli.new(argv, io).run
       expect(io.string).to match(/Error during packaging: .+/)
     end
   end


### PR DESCRIPTION
This pull request allows gems to be copied from the local gemset instead of having to run `bundler install` again. The speed up is quite significant, although there was some monkey patching necessary to be able to handle excluded groups.