### PR TITLE
Fixes to path handling

### DIFF
--- a/lib/tara/archive.rb
+++ b/lib/tara/archive.rb
@@ -146,7 +146,7 @@ module Tara
 
     def copy_file(project_dir, package_dir, file)
       relative_file = file.relative_path_from(project_dir)
-      if relative_file.directory?
+      if file.directory?
         unless (dirname = relative_file.dirname) == DOT_PATH
           FileUtils.mkdir_p(package_dir.join(dirname))
         end

--- a/lib/tara/installer.rb
+++ b/lib/tara/installer.rb
@@ -124,9 +124,9 @@ module Tara
     end
 
     def copy_gem_files(path)
-      Dir['Gemfile', 'Gemfile.lock', '*.gemspec'].each do |file|
-        if File.exist?(@app_dir.join(file))
-          FileUtils.cp(@app_dir.join(file), path.join(File.basename(file)))
+      Dir.chdir(@app_dir) do
+        Dir['Gemfile', 'Gemfile.lock', '*.gemspec'].each do |file|
+          FileUtils.cp(file, path.join(File.basename(file)))
         end
       end
     end

--- a/spec/integration/cli_integration_spec.rb
+++ b/spec/integration/cli_integration_spec.rb
@@ -25,7 +25,8 @@ describe 'bin/tara' do
   end
 
   def argv
-    %W[--app-name #{app_name} --app-dir #{app_dir} --download-dir #{download_dir} --target #{detect_target} --traveling-ruby-version #{traveling_ruby_version}]
+    traveling_ruby_version_flag = traveling_ruby_version ? "--traveling-ruby-version #{traveling_ruby_version}" : ''
+    %W[--app-name #{app_name} --app-dir #{app_dir} --download-dir #{download_dir} --target #{detect_target} #{traveling_ruby_version_flag}]
   end
 
   def archive_path

--- a/spec/integration/cli_integration_spec.rb
+++ b/spec/integration/cli_integration_spec.rb
@@ -25,8 +25,12 @@ describe 'bin/tara' do
   end
 
   def argv
-    traveling_ruby_version_flag = traveling_ruby_version ? "--traveling-ruby-version #{traveling_ruby_version}" : ''
-    %W[--app-name #{app_name} --app-dir #{app_dir} --download-dir #{download_dir} --target #{detect_target} #{traveling_ruby_version_flag}]
+    args = %W[--app-name #{app_name} --app-dir #{app_dir} --download-dir #{download_dir} --target #{detect_target}]
+    if traveling_ruby_version
+      args << '--traveling-ruby-version'
+      args << traveling_ruby_version
+    end
+    args
   end
 
   def archive_path


### PR DESCRIPTION
I discovered a few things that simply did not work, or where assumptions were made about paths that made things break. Specifically I tested things with a repo where the app was not in the root directory. I thought that would be covered by the tests since the example app is not in the root, so I'm unsure as to how the tests pass.

The tests also seem to assume that the `TRAVELING_RUBY_VERSION` environment variable is set, because if it's not they will pass `--traveling-ruby-version ''`, which doesn't work. This has also been fixed.

@mthssdrbrg could you review, merge and release a new version, or would you like to give me commit rights + ownership of the gem?