### PR TITLE
Widen the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,11 @@ cache:
     - $HOME/.tara/downloads
 matrix:
   include:
-    - rvm: ruby-2.1.5
-      env: TRAVELING_RUBY_VERSION=20150210
     - rvm: ruby-2.1.6
-      env: TRAVELING_RUBY_VERSION=20150715
+      env: TRAVELING_RUBY_VERSION=20150210
     - rvm: ruby-2.2.2
+      env: TRAVELING_RUBY_VERSION=20150715
+    - rvm: ruby-2.3.3
+      env: TRAVELING_RUBY_VERSION=20150715
+    - rvm: ruby-2.4.0
       env: TRAVELING_RUBY_VERSION=20150715


### PR DESCRIPTION
Remove 2.1.5 and add 2.3.3 and 2.4.0. Make 2.1.6 build with the older release of Traveling Ruby, to continue to cover that.